### PR TITLE
fix circuit knitting blog  image formatting

### DIFF
--- a/_posts/2024-08-27-Circuit-Knitting-Blog.md
+++ b/_posts/2024-08-27-Circuit-Knitting-Blog.md
@@ -94,7 +94,9 @@ The QPD contains two types of operations. Basis measurements and state initializ
 
 The subcircuits will then be
 
-![example of a subcircuit produced by a wire cut](/assets/images/Circuit-Knitting-Blog/wire-cut-example-sub1.png) ![example of a subcircuit produced by a wire cut](/assets/images/Circuit-Knitting-Blog/wire-cut-example-sub2.png)
+![example of a subcircuit produced by a wire cut](/assets/images/Circuit-Knitting-Blog/wire-cut-example-sub1.png)
+
+![example of a subcircuit produced by a wire cut](/assets/images/Circuit-Knitting-Blog/wire-cut-example-sub2.png)
 
 Now to be able to estimate the original circuit's expectation values we need to insert operations from the <a href="#qdplist">QPD</a>, creating a total of 8 subcircuit pairs (one for each row in the <a href="#qdplist">QPD</a> ). In a more general setting, the total number of subcircuit groups of size *k* is given by $ 8^n $, where *n* is the number of cuts made and *k* is the number of parts the circuit is cut to. In addition to the number of circuits, also the number of samples needed scales exponentially with the number of cuts. Thus, the time complexity scales exponentially with the number of cuts. The sampling overhead can be represented in the big-O notation as O($\gamma^{2n}$) <a href="#references">[4]</a>, where $ \gamma $ is the sum of the absolute values of the coefficients of the QPD (4 for wire-cutting). If more than one cut is made the operations for each circuit are given by the cartesian product of the QPD with itself repeated for each cut. After running all of the subcircuits on a simulator or a quantum computer we can use classical post-processing to reconstruct the expectation values.
 
@@ -148,7 +150,9 @@ cut_circuit.draw("mpl")
 
 After this, we can use QCut to separate the cut_circuit from the cut location and generate all the needed experiment circuits by inserting operations from the QPD. Once we have the experiment circuits we can then execute them and estimate the expectation values of the original circuit using QCut. Here we have calculated the expectation values using the Helmi quantum computer both with and without QCut. Additionally, the expectation values have also been calculated with an ideal simulator. The separated subcircuits before inserting gates from QPD and the final results can be seen below.
 
-![subcircuit produced by QCut](/assets/images/Circuit-Knitting-Blog/cut-circuit-sub1.png) ![subcircuit produced by QCut](/assets/images/Circuit-Knitting-Blog/cut-circuit-sub2.png)
+![subcircuit produced by QCut](/assets/images/Circuit-Knitting-Blog/cut-circuit-sub1.png)
+
+![subcircuit produced by QCut](/assets/images/Circuit-Knitting-Blog/cut-circuit-sub2.png)
 
 ![bar plot of expectation values](/assets/images/Circuit-Knitting-Blog/results-bar-plot.png)
 


### PR DESCRIPTION
Fix circuit knitting blog  image formatting
- add a linebreak between images where it was missing