### PR TITLE
Fix bug

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,3 +11,8 @@ search: false
 a {
     word-break: break-all;
 }
+
+h1 a, h2 a, h3 a, h4 a, h5 a {
+    word-break: normal;
+}
+

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -7,3 +7,7 @@ search: false
 
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
+
+a {
+    word-break: break-all;
+}


### PR DESCRIPTION
Titles generated by jekyll are the same HTML element as links. Added another CSS rule to fix improper wrapping of titles.