### PR TITLE
fix titles wrapping improperly

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,3 +11,7 @@ search: false
 a {
     word-break: break-all;
 }
+
+h1 a, h2 a, h3 a, h4 a, h5 a {
+    word-break: normal;
+}


### PR DESCRIPTION
The titles added by Jekyll are the same HTML element as links. Added CSS to prevent titles from improperly wrapping in the middle of words