### PR TITLE
Helmi end of life

### DIFF
--- a/content/_data/constants.yml
+++ b/content/_data/constants.yml
@@ -249,7 +249,7 @@ cookie_consent:
       href: https://www.lumi-supercomputer.eu/lumi-service-status/
   alert:
     text: |-
-      VTT Q5 (Helmi) is currently down pending maintenance.
+      VTT Q5 (Helmi) will be indefinitely offline and will be removed from our services soon.
     type: warning # Alert type can be info, warning, or error
   quantum-computers:
     - name: VTT Q5 (Helmi)

--- a/content/_publications/2026-05-08-Helmi-End-of-Life.md
+++ b/content/_publications/2026-05-08-Helmi-End-of-Life.md
@@ -1,0 +1,28 @@
+---
+title: 'Helmi End of Life'
+date: 2026-05-08
+collection: publications
+header:
+  teaser: /assets/images/about-icon.webp
+published: true
+author: FiQCI
+layout: post
+tags:
+  - Helmi VTT-Q5
+filters:
+  Skill level: Beginner # Beginner, Advanced
+  Type: News # Blog, Instructions, News
+  Theme: Technical # Technical, Algorithm, Programming, HPC+QC+AI
+---
+
+**Dear Helmi users,**
+
+We are at the end of an era. Helmi has served us well for five years. Now it is time to say goodbye to our small-but-precious pearl.
+
+Helmi holds a special place as the first Finnish quantum computer, marking an important milestone in our journey. Its contributions have laid the groundwork for the advancements we continue to build today.
+
+The journey of the Finnish Quantum-Computing Infrastructure continues with the VTT Q50 and the Aalto Q20 quantum computers, both connected to the LUMI supercomputer for hybrid HPC+AI+QC.
+
+A big thank you is in place for all the users of Helmi. We have learned a lot from you during this journey, and we hope that Helmi has proved to be useful for you as well!
+
+Best regards on behalf of entire FiQCI team at VTT, Aalto, and CSC!


### PR DESCRIPTION
- add helmi end of life status page note and a blog post
- Helmi not yet removed from status/get access pages. This will happen later